### PR TITLE
Add support for folders of custom lists and "configuration" via constants

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -491,11 +491,11 @@ for folder_name, widget_data in sub_custom_lists.items():
         'FUNCTION': "generatePrompt",
         'CATEGORY': f"AI WizArt/Prompt Composer Tools",
         
-        'INPUT_TYPES': classmethod(lambda cls: {
+        'INPUT_TYPES': classmethod(lambda cls, widget_data=widget_data: {
             "optional": {
                 "text_in_opt": ("STRING", {"forceInput": True}),
             },
-            "required": widget_data 
+            "required": widget_data
         }),
         'generatePrompt': generatePrompt
     }

--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,14 @@
 
 import os
 
+# Weight min, max and step values
+WEIGHT_MIN = 0
+WEIGHT_MAX = 1.95
+WEIGHT_STEP = 0.05
+
+# Weight display format (number or slider)
+WEIGHT_DISPLAY = "slider"
+
 script_dir = os.path.dirname(__file__)
 
 # Read txt file
@@ -32,10 +40,10 @@ def customLists(folder):
             custom_lists[str(filename)] = (values, { "default" : values[0]})
             custom_lists[str(filename) + "_weight"] = ("FLOAT", {
                 "default": 1,
-                "min": 0,
-                "max": 1.95,
-                "step": 0.05,
-                "display": "slider"
+                "min": WEIGHT_MIN,
+                "max": WEIGHT_MAX,
+                "step": WEIGHT_STEP,
+                "display": WEIGHT_DISPLAY
             })
 
     custom_lists["active"] = ("BOOLEAN", {"default": True})
@@ -59,18 +67,8 @@ def subCustomLists(folder):
 
 sub_custom_lists = subCustomLists(script_dir + "/custom-lists")
 
-# Dump sub_custom_lists variable to console and stop app execution
-# print(custom_lists)
-# print("\n\n")
-# print(sub_custom_lists)
-# raise SystemExit
 
-
-
-
-
-# Apply weight
-    
+# Apply weight    
 def applyWeight(text, weight):
     if weight == 1:
         return text
@@ -138,10 +136,10 @@ class PromptComposerTextSingle:
                 }),
                 "weight": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "active": ("BOOLEAN", {"default": False}),
             }
@@ -180,100 +178,100 @@ class promptComposerTextMultiple:
                 }),
                 "weight_1": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_2": ("STRING", {
                     "multiline": True
                 }),
                 "weight_2": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_3": ("STRING", {
                     "multiline": True
                 }),
                 "weight_3": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_4": ("STRING", {
                     "multiline": True
                 }),
                 "weight_4": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_5": ("STRING", {
                     "multiline": True
                 }),
                 "weight_5": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_6": ("STRING", {
                     "multiline": True
                 }),
                 "weight_6": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_7": ("STRING", {
                     "multiline": True
                 }),
                 "weight_7": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_8": ("STRING", {
                     "multiline": True
                 }),
                 "weight_8": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_9": ("STRING", {
                     "multiline": True
                 }),
                 "weight_9": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "text_10": ("STRING", {
                     "multiline": True
                 }),
                 "weight_10": ("FLOAT", {
                     "default": 1,
-                    "min": 0,
-                    "max": 1.95,
-                    "step": 0.05,
-                    "display": "slider"
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "step": WEIGHT_STEP,
+                    "display": WEIGHT_DISPLAY
                 }),
                 "active": ("BOOLEAN", {"default": False}),
             }
@@ -330,10 +328,10 @@ class PromptComposerStyler:
                 }),
                 "style_weight": ("FLOAT", {
                     "default": 1,
-                    "step": 0.05,
-                    "min": 0,
-                    "max": 1.95,
-                    "display": "slider",
+                    "step": WEIGHT_STEP,
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "display": WEIGHT_DISPLAY,
                 }),
                 "active": ("BOOLEAN", {"default": False}),
             },
@@ -372,10 +370,10 @@ class PromptComposerEffect:
                 }),
                 "effect_weight": ("FLOAT", {
                     "default": 1,
-                    "step": 0.05,
-                    "min": 0,
-                    "max": 1.95,
-                    "display": "slider",
+                    "step": WEIGHT_STEP,
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "display": WEIGHT_DISPLAY,
                 }),
                 "active": ("BOOLEAN", {"default": False}),
             },
@@ -409,10 +407,10 @@ class PromptComposerGrouping:
                 "text_in": ("STRING", {"forceInput": True}),
                 "weight": ("FLOAT", {
                     "default": 1,
-                    "step": 0.05,
-                    "min": 0,
-                    "max": 1.95,
-                    "display": "slider",
+                    "step": WEIGHT_STEP,
+                    "min": WEIGHT_MIN,
+                    "max": WEIGHT_MAX,
+                    "display": WEIGHT_DISPLAY,
                 }),
                 "active": ("BOOLEAN", {"default": False}),
             }

--- a/__init__.py
+++ b/__init__.py
@@ -7,10 +7,10 @@
 # Weight min, max and step values
 WEIGHT_MIN = 0
 WEIGHT_MAX = 1.95
-WEIGHT_STEP = 0.05
+WEIGHT_STEP = 0.1
 
 # Weight display format (number or slider)
-WEIGHT_DISPLAY = "slider"
+WEIGHT_DISPLAY = "number"
 
 ######## DO NOT MODIFY BELOW THIS LINE ########
 

--- a/custom-lists/Clothing/Complex.txt
+++ b/custom-lists/Clothing/Complex.txt
@@ -1,0 +1,39 @@
+wearing square neck
+wearing flounce short sleeve
+wearing shirred ruffle hem
+wearing dress
+wearing cropped turtleneck
+wearing sweater lantern
+wearing sleeve ribbed knit
+wearing pullover sweater
+wearing jumper
+wearing lightweight
+wearing long-sleeve
+wearing water-resistant
+wearing puffer jacket
+wearing casual long sleeve
+wearing draped open front
+wearing knit pockets long
+wearing cardigan jackets
+wearing sweater
+wearing elegant floral print
+wearing petal cap sleeve
+wearing pleated vacation
+wearing office work blouse
+wearing top
+wearing classic-fit
+wearing short-sleeve v-neck
+wearing t-shirt
+wearing slim-fit thin strap
+wearing tank
+wearing casual hoodies
+wearing pullover tops
+wearing drawstring long
+wearing sleeve sweatshirts
+wearing fall clothes with
+wearing pocket
+wearing casual long sleeve
+wearing color block solid
+wearing tops crewneck
+wearing sweatshirts cute
+wearing loose fit pullovers

--- a/custom-lists/Clothing/Generic.txt
+++ b/custom-lists/Clothing/Generic.txt
@@ -1,0 +1,10 @@
+wearing dress
+wearing sweater
+wearing jacket
+wearing cardigan
+wearing blouse
+wearing t-shirt
+wearing shirt
+wearing tank top
+wearing hoodie
+wearing sweatshirt


### PR DESCRIPTION
As requested in #2, I think this would be a great feature to have.  This MR allows the user to create folders inside the `custom-lists` folder and add .txt lists inside them.

When the custom node is loaded in ComfyUI it now:
* scans the `custom-lists` directory for .txt files and create a custom node called "Prompt Composer Custom Lists" based in the lists found 
  * this is the standard existing behavior
* scans the `custom-lists` directory for sub directories and add a custom node for each directory found, in the format "Prompt Composer List - <FOLDER_NAME>"
  * these nodes work the same way as the standard ones, but only include the .txt files from within the folder

I will add some examples to the PR so that the user can check the existing files and build upon them.

When rendered inside ComfyUI, the example look like this:
![image](https://github.com/user-attachments/assets/4ec796be-c9d6-4a4a-b9d3-d84d9b1a63a9)

from a folder structure like this:
```
> custom-lists
  > Clothing
    > Complex.txt
    > Generic.txt
```

---

I also added a couple improvements to the code (since my PR mostly just replicate existing code) and moved a couple values to constants in the top of the code. The user can even edit those if they so wish (As requested in #2 too). I know having actual configuration settings in comfy itself would be even better but I don't know how to do that so 😁 

For more info about the changes please check the code comments in this PR. Thanks!