### PR TITLE
Fix Python 3.12 and ComfyUI node loading for PromptComposer nodes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@
 # Version: 1.7
 # https://stefanoflore.it
 # https://ai-wiz.art
+
 import os
 
 from .nodes.custom_lists import PromptComposerCustomLists
@@ -19,11 +20,14 @@ from .nodes import utils
 script_dir = os.path.dirname(__file__)
 
 NODE_CLASS_MAPPINGS = {
-    "PromptComposerCustomLists": PromptComposerCustomLists(script_dir),
+    # Fixed nodes (classes only, no args)
+    "PromptComposerCustomLists": PromptComposerCustomLists,
+    "PromptComposerStyler": PromptComposerStyler,
+    "PromptComposerEffect": PromptComposerEffect,
+
+    # Unchanged nodes
     "PromptComposerTextSingle": PromptComposerTextSingle,
     "promptComposerTextMultiple": PromptComposerTextMultiple,
-    "PromptComposerStyler": PromptComposerStyler(script_dir),
-    "PromptComposerEffect": PromptComposerEffect(script_dir),
     "PromptComposerGrouping": PromptComposerGrouping,
     "PromptComposerMerge": PromptComposerMerge,
 }
@@ -39,12 +43,16 @@ NODE_DISPLAY_NAME_MAPPINGS = {
 }
 
 # Generate the widgets for each folder of custom lists
-sub_custom_lists = utils.sub_custom_lists(script_dir + "/custom-lists")
+sub_custom_lists = utils.sub_custom_lists(
+    os.path.join(script_dir, "custom-lists")
+)
 
 for folder_name, widget_data in sub_custom_lists.items():
     class_name = "PromptComposerListFolders" + folder_name.capitalize()
     new_class = create_list_folders_class(class_name, widget_data)
 
-    # Add the new class to the mappings
+    # Classes only — still correct here
     NODE_CLASS_MAPPINGS[class_name] = new_class
-    NODE_DISPLAY_NAME_MAPPINGS[class_name] = f"Prompt Composer List - {folder_name.capitalize()}"
+    NODE_DISPLAY_NAME_MAPPINGS[class_name] = (
+        f"Prompt Composer List - {folder_name.capitalize()}"
+    )

--- a/nodes/custom_lists.py
+++ b/nodes/custom_lists.py
@@ -1,6 +1,6 @@
 from . import utils
+import os
 
-# Prompt Composer Custom Lists
 class PromptComposerCustomLists:
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("text_out",)
@@ -8,16 +8,19 @@ class PromptComposerCustomLists:
     CATEGORY = "AI WizArt/Prompt Composer Tools"
 
     generatePrompt = utils.generate_prompt
-    custom_lists  = None
-
-    def __init__(self, script_dir: str):
-        PromptComposerCustomLists.custom_lists  = utils.custom_lists(script_dir + "/custom-lists")
+    custom_lists = None
 
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
+        if cls.custom_lists is None:
+            base_dir = os.path.dirname(os.path.dirname(__file__))
+            cls.custom_lists = utils.custom_lists(
+                os.path.join(base_dir, "custom-lists")
+            )
+
         return {
             "optional": {
                 "text_in_opt": ("STRING", {"forceInput": True}),
             },
-            "required": s.custom_lists
+            "required": cls.custom_lists
         }

--- a/nodes/effect.py
+++ b/nodes/effect.py
@@ -1,7 +1,6 @@
 import os
 from . import utils
 
-# Effect Node
 class PromptComposerEffect:
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("text_out",)
@@ -10,25 +9,23 @@ class PromptComposerEffect:
 
     effects = None
 
-    def __init__(self, script_dir: str):        
-        effects = utils.read_words_from_file(os.path.join(script_dir, "lists/effects.txt"))
-
-        effects.sort()
-        
-        effects = ['-'] + effects
-
-        PromptComposerEffect.effects = effects
-
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
+        if cls.effects is None:
+            base_dir = os.path.dirname(os.path.dirname(__file__))
+            effects = utils.read_words_from_file(
+                os.path.join(base_dir, "lists", "effects.txt")
+            )
+
+            effects.sort()
+            cls.effects = ['-'] + effects
+
         return {
             "optional": {
                 "text_in_opt": ("STRING", {"forceInput": True}),
             },
             "required": {
-                "effect": (s.effects, {
-                    "default": s.effects[0],
-                }),
+                "effect": (cls.effects, {"default": cls.effects[0]}),
                 "effect_weight": ("FLOAT", {
                     "default": 1,
                     "step": utils.WEIGHT_STEP,
@@ -43,14 +40,11 @@ class PromptComposerEffect:
     def promptComposerEffect(self, text_in_opt="", effect="-", effect_weight=0, active=True):
         prompt = []
 
-        if text_in_opt != "":
+        if text_in_opt:
             prompt.append(text_in_opt)
         if effect != '-' and effect_weight > 0 and active:
-            prompt.append(f"({effect} effect:{round(effect_weight,2)})")
-        if len(prompt) > 0:
-            prompt = ", ".join(prompt)
-            prompt = prompt.lower()
+            prompt.append(f"({effect} effect:{round(effect_weight, 2)})")
 
-            return(prompt,)
-        else:
-            return("",)
+        if prompt:
+            return (", ".join(prompt).lower(),)
+        return ("",)

--- a/nodes/styler.py
+++ b/nodes/styler.py
@@ -1,7 +1,6 @@
 import os
 from . import utils
 
-# Styler Node
 class PromptComposerStyler:
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("text_out",)
@@ -10,25 +9,23 @@ class PromptComposerStyler:
 
     styles = None
 
-    def __init__(self, script_dir: str):
-        styles = utils.read_words_from_file(os.path.join(script_dir, "lists/styles.txt"))
-
-        styles.sort()
-
-        styles = ['-'] + styles
-
-        PromptComposerStyler.styles = styles
-
     @classmethod
-    def INPUT_TYPES(s):
+    def INPUT_TYPES(cls):
+        if cls.styles is None:
+            base_dir = os.path.dirname(os.path.dirname(__file__))
+            styles = utils.read_words_from_file(
+                os.path.join(base_dir, "lists", "styles.txt")
+            )
+
+            styles.sort()
+            cls.styles = ['-'] + styles
+
         return {
             "optional": {
                 "text_in_opt": ("STRING", {"forceInput": True}),
             },
             "required": {
-                "style": (s.styles, {
-                    "default": s.styles[0],
-                }),
+                "style": (cls.styles, {"default": cls.styles[0]}),
                 "style_weight": ("FLOAT", {
                     "default": 1,
                     "step": utils.WEIGHT_STEP,
@@ -39,18 +36,15 @@ class PromptComposerStyler:
                 "active": ("BOOLEAN", {"default": False}),
             },
         }
-    
+
     def promptComposerStyler(self, text_in_opt="", style="-", style_weight=0, active=True):
         prompt = []
 
-        if text_in_opt != "":
+        if text_in_opt:
             prompt.append(text_in_opt)
         if style != '-' and style_weight > 0 and active:
-            prompt.append(f"({style} style:{round(style_weight,2)})")
-        if len(prompt) > 0:
-            prompt = ", ".join(prompt)
-            prompt = prompt.lower()
+            prompt.append(f"({style} style:{round(style_weight, 2)})")
 
-            return(prompt,)
-        else:
-            return("",)
+        if prompt:
+            return (", ".join(prompt).lower(),)
+        return ("",)


### PR DESCRIPTION
Updated PromptComposerCustomLists, PromptComposerStyler, and PromptComposerEffect nodes:
Removed constructor arguments (nodes now class-level).
Moved initialization of lists/effects/styles to INPUT_TYPES() for proper lazy loading.
Fully compatible with Python 3.12 and current ComfyUI introspection.
Resolves TypeError: issubclass() arg 1 must be a class errors on node load.
